### PR TITLE
Shorten "Quick Reply" string

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -26,7 +26,7 @@
     <string name="toast_sending_message">Sending message</string>
 
     <!-- QM - Quick reply -->
-    <string name="qm_quick_reply">Quick reply</string>
+    <string name="qm_quick_reply">Reply</string>
     <string name="qm_mark_read">Read</string>
 
     <!-- Delay delivery -->


### PR DESCRIPTION
Remove redundant verbiage from Quick Reply option in Mms notification pull-down. We're already "quick replying", so all we need to see is "Reply". This fixes the string being cut off due to the "Mark as read" function being added back in.
